### PR TITLE
Update NFTDogs.sol

### DIFF
--- a/NFTDogs.sol
+++ b/NFTDogs.sol
@@ -69,7 +69,7 @@ contract NFTDogs is ERC721, ERC721Enumerable, ERC721URIStorage, Ownable {
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(ERC721, ERC721Enumerable)
+        override(ERC721, ERC721Enumerable, ERC721URIStorage)
         returns (bool)
     {
         return super.supportsInterface(interfaceId);


### PR DESCRIPTION
(fixed) Gives error:
TypeError: Function needs to specify overridden contract "ERC721URIStorage".
  --> NFTDogs.sol:72:9:
   |
72 |         override(ERC721, ERC721Enumerable)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: This contract: 
  --> @openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol:12:1:
   |
12 | abstract contract ERC721URIStorage is IERC4906, ERC721 {
   | ^ (Relevant source part starts here and spans across multiple lines).